### PR TITLE
Fixed kernel analyzer to work with clang

### DIFF
--- a/kernel-analyzer/src/lib/Annotation.cc
+++ b/kernel-analyzer/src/lib/Annotation.cc
@@ -421,7 +421,7 @@ std::string getAnonStructId(Value *V, Module *M, StringRef Prefix) {
     break;
   }
 
-  return Prefix;
+  return Prefix.str();
 }
 
 std::string getAnnotation(Value *V, Module *M) {

--- a/kernel-analyzer/src/lib/Annotation.h
+++ b/kernel-analyzer/src/lib/Annotation.h
@@ -56,7 +56,7 @@ static inline bool isFunctionPointerOrVoid(llvm::Type *Ty) {
 
 static inline std::string getScopeName(const llvm::GlobalValue *GV) {
   if (llvm::GlobalValue::isExternalLinkage(GV->getLinkage()))
-    return GV->getName();
+    return GV->getName().str();
   else {
     llvm::StringRef moduleName =
         llvm::sys::path::stem(GV->getParent()->getModuleIdentifier());
@@ -157,10 +157,10 @@ static inline std::string getValueId(llvm::Value *V) {
   else if (llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(V)) {
     if (llvm::Function *F = CI->getCalledFunction())
       if (F->getName().startswith("kint_arg.i"))
-        return getLoadStoreId(CI);
+        return getLoadStoreId(CI).str();
     return getRetId(CI);
   } else if (llvm::isa<llvm::LoadInst>(V) || llvm::isa<llvm::StoreInst>(V)) {
-    return getLoadStoreId(llvm::dyn_cast<llvm::Instruction>(V));
+    return getLoadStoreId(llvm::dyn_cast<llvm::Instruction>(V)).str();
   } else if (llvm::isa<llvm::AllocaInst>(V)) {
     return getVarId(llvm::dyn_cast<llvm::AllocaInst>(V));
   } else if (llvm::Instruction *I = llvm::dyn_cast<llvm::Instruction>(V)) {

--- a/kernel-analyzer/src/lib/Common.h
+++ b/kernel-analyzer/src/lib/Common.h
@@ -38,7 +38,7 @@ extern cl::opt<unsigned> VerboseLevel;
   do {                                                                         \
     if (VerboseLevel >= lv && I) {                                             \
       if (DILocation *Loc = I->getDebugLoc()) {                                \
-        string file = Loc->getFilename();                                      \
+        string file = Loc->getFilename().str();                                \
         unsigned line = Loc->getLine();                                        \
         errs() << file << ":" << line << "\n";                                 \
       }                                                                        \

--- a/kernel-analyzer/src/lib/KAMain.cc
+++ b/kernel-analyzer/src/lib/KAMain.cc
@@ -110,7 +110,7 @@ void doBasicInitialization(Module *M) {
   // collect global object definitions
   for (GlobalVariable &G : M->globals()) {
     if (G.hasExternalLinkage())
-      GlobalCtx.Gobjs[G.getName()] = &G;
+      GlobalCtx.Gobjs[G.getName().str()] = &G;
   }
 
   // collect global function definitions


### PR DESCRIPTION
Clang built with O0 patch ([link](https://github.com/Markakd/LLVM-O0-BitcodeWriter)) doesn't build the KINT, throwing some errors mainly due to StringRef->std::string conversion. To solve it one must add `.str()`. This patch makes it compile properly.